### PR TITLE
Configure curl with config file

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.CR_PAT }}
 
       - name: build-push-pr
         if: github.event_name == 'pull_request'

--- a/README.md
+++ b/README.md
@@ -10,12 +10,6 @@ This is a useful resource for pipeline development time, while a required artifa
 
 * `filename`: *Optional.* The name of the file for the downloaded artifact to be save as. If not provided, the file will be saved using the full url string as its name.
 
-* `username`: *Optional.* Username for accessing an authenticated repository.
-
-* `password`: *Optional.* Password for accessing an authenticated repository.
-
-* `skip_ssl_verification`: *Optional.* Skips ssl verification if defined as `true`. Default is `false`.
-
 * `extra_args`: *Optional.* Specify extra arguments for `curl`.
 
 ### Example
@@ -25,16 +19,16 @@ Resource configuration:
 ``` yaml
 resource_types:
 - name: file-url
-  type: docker-image
+  type: registry-image
   source:
-    repository: pivotalservices/concourse-curl-resource
-    tag: latest
+    repository: ghcr.io/3dhubs/concourse-curl-resource
+    tag: master
 
 resources:
 - name: my-file
   type: file-url
   source:
-    url: http://www-us.apache.org/dist/lucene/java/5.5.4/lucene-5.5.4-src.tgz  
+    url: https://www.apache.org/dist/lucene/java/5.5.4/lucene-5.5.4-src.tgz  
     filename: lucene-5.5.4-src.tgz  
 ```
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This is a useful resource for pipeline development time, while a required artifa
 
 * `filename`: *Optional.* The name of the file for the downloaded artifact to be save as. If not provided, the file will be saved using the full url string as its name.
 
-* `extra_args`: *Optional.* Specify extra arguments for `curl`.
+* `config`: *Optional.* String to be used as a configuration file for `curl --config`.
 
 ### Example
 
@@ -28,8 +28,16 @@ resources:
 - name: my-file
   type: file-url
   source:
-    url: https://www.apache.org/dist/lucene/java/5.5.4/lucene-5.5.4-src.tgz  
-    filename: lucene-5.5.4-src.tgz  
+    url: https://www.apache.org/dist/lucene/java/5.5.4/lucene-5.5.4-src.tgz
+    filename: lucene-5.5.4-src.tgz
+
+- name: file-requiring-auth
+  type: file-url
+  source:
+    url: https://www.apache.org/dist/lucene/java/5.5.4/lucene-5.5.4-src.tgz
+    filename: lucene-5.5.4-src.tgz
+    config: |
+      user username:password
 ```
 
 ## Behavior

--- a/assets/check
+++ b/assets/check
@@ -9,15 +9,16 @@ source "$(dirname $0)/common.sh"
 
 tmpd="$(mktemp -d /tmp/concourse-curl-resource-request.XXXXXX)"
 payload="$tmpd/payload"
+config="$tmpd/config"
 
 cat > "$payload" <&0
 
 url="$(jq -r '.source.url // ""' < $payload)"
-extra_args="$(jq -r '.source.extra_args // ""' < $payload)"
+jq -r '.source.config // ""' < "$payload" > "$config"
 
 if test -z "$url"; then
   echo "invalid payload (missing url)"
   exit 1
 fi
 
-check_version "$tmpd" "$url" "$extra_args" >&3
+check_version "$tmpd" "$url" >&3

--- a/assets/common.sh
+++ b/assets/common.sh
@@ -2,11 +2,9 @@ check_version() {
   # args
   local tmpd="$1"
   local url="$2"
-  local args="$3"
-  shift 3
 
   # retrieves HTTP header of file URL response
-  curl -fsSL -o "$tmpd/result" -R -I --url "$url" $args
+  curl -fsSL -o "$tmpd/result" -R -I --config "$tmpd/config" --url "$url"
   local lastModifiedHeader=$(grep -i 'last-modified:' < "$tmpd/result")
 
   # Checks if field "Last-Modified" exists in HTTP header and transform it into timestamp string

--- a/assets/in
+++ b/assets/in
@@ -9,24 +9,25 @@ source "$(dirname $0)/common.sh"
 
 tmpd="$(mktemp -d /tmp/concourse-curl-resource-request.XXXXXX)"
 payload="$tmpd/payload"
+config="$tmpd/config"
 
 cat > "$payload" <&0
 
 url="$(jq -r '.source.url // ""' < $payload)"
 filename="$(jq -r '.source.filename // "file"' < $payload)"
-extra_args="$(jq -r '.source.extra_args // ""' < $payload)"
+jq -r '.source.config // ""' < "$payload" > "$config"
 
 if test -z "$url"; then
   echo "invalid payload (missing url)"
   exit 1
 fi
 
-version=$(check_version "$tmpd" "$url" "$extra_args")
+version=$(check_version "$tmpd" "$url")
 if test -z "$version"; then
   echo "Version could not be retrieved"
   exit 1
 fi
 
-curl -fsSL -o "$1/$filename" -R --url "$url" $extra_args
+curl -fsSL -o "$1/$filename" -R --config "$config" --url "$url"
 
 jq -n "{ version: {version: $(echo $version | jq .[].version )}}" >&3

--- a/test/test-check.sh
+++ b/test/test-check.sh
@@ -24,7 +24,7 @@ it_can_get_file_with_basic_auth() {
   jq -n "{
     source: {
       url: \"https://httpbin.org/basic-auth/aerobatic/aerobatic\",
-      extra_args: \"-u aerobatic:aerobatic\",
+      config: \"user aerobatic:aerobatic\",
     }
   }" | $resource_dir/check | tee /dev/stderr
 }

--- a/test/test-in.sh
+++ b/test/test-in.sh
@@ -19,7 +19,7 @@ it_can_get_file_with_basic_auth() {
   jq -n "{
     source: {
       url: \"https://httpbin.org/basic-auth/aerobatic/aerobatic\",
-      extra_args: \"-u aerobatic:aerobatic\",
+      config: \"user aerobatic:aerobatic\",
     }
   }" | $resource_dir/in "$tmpd" | tee /dev/stderr
 


### PR DESCRIPTION
Passing extra arguments on the command line leads to all sorts of trauma with string interpolation in bash. It's easier to create a curl configuration file.
